### PR TITLE
Use next_page in repos_issues to ensure all issues are retrieved

### DIFF
--- a/rt-to-github.pl
+++ b/rt-to-github.pl
@@ -96,6 +96,13 @@ $rt->login(
 my @gh_issues =
   $gh_issue->repos_issues( $github_repo_owner, $github_repo, { state => 'all' } );
 
+# repos_issues may not return all issues, so need to check
+# if there are more and keep going until we have them all
+while ( $gh_issue->has_next_page ) {
+  my @next_page = $gh_issue->next_page;
+  push( @gh_issues,@next_page );
+}
+
 my %rt_gh_map;
 for my $i (@gh_issues) {
     if ( $i->{title} =~ /\[rt\.cpan\.org #(\d+)\]/ ) {


### PR DESCRIPTION
Hi Dave,

Nice implementation (way better than mine, so i've nuked my script and pointed the README at your repo). I think you have the problem of not grabbing all issues for repos that have a large number however, so i've added the call to ->has_next_page to make sure the gh_issues array is fully populated with all issues.
