### PR TITLE
Allow for spaces in PAUSE passwords.

### DIFF
--- a/rt-to-github.pl
+++ b/rt-to-github.pl
@@ -39,7 +39,15 @@ sub _git_config {
 sub _pause_rc {
     my $key = shift;
     if ( $pause_rc->exists && !%pause ) {
-        %pause = split " ", $pause_rc->slurp;
+        my @pause = split qr{$/}, $pause_rc->slurp;
+        for my $line (@pause) {
+            my @credentials = split ' ', $line;
+            my $key_name = shift @credentials;
+            $pause{$key_name}
+                = $key_name eq 'password'
+                ? join ' ', @credentials
+                : shift @credentials;
+        }
     }
     return $pause{$key} // '';
 }


### PR DESCRIPTION
I was playing with this script today and found that it didn't want to DTRT with a PAUSE password which includes spaces.