### PR TITLE
Use Config::Identity for encrypted .pause support

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,3 +7,4 @@ requires "RT::Client::REST::Ticket";
 requires "RT::Client::REST::User";
 requires "Syntax::Keyword::Junction";
 requires "Try::Tiny";
+requires "Config::Identity::PAUSE";

--- a/rt-to-github.pl
+++ b/rt-to-github.pl
@@ -15,6 +15,7 @@ use RT::Client::REST::User;
 use Syntax::Keyword::Junction qw/any/;
 use Try::Tiny;
 use Getopt::Long;
+use Config::Identity::PAUSE;
 
 binmode( STDOUT, ":utf8" );
 
@@ -40,15 +41,7 @@ sub _git_config {
 sub _pause_rc {
     my $key = shift;
     if ( $pause_rc->exists && !%pause ) {
-        my @pause = split qr{$/}, $pause_rc->slurp;
-        for my $line (@pause) {
-            my @credentials = split ' ', $line;
-            my $key_name = shift @credentials;
-            $pause{$key_name}
-                = $key_name eq 'password'
-                ? join ' ', @credentials
-                : shift @credentials;
-        }
+		%pause = Config::Identity::PAUSE->load_check;
     }
     return $pause{$key} // '';
 }


### PR DESCRIPTION
This uses `Config::Identity` for encrypted .pause support