### PR TITLE
Eliminate Syntax::Keyword::Junction dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,5 +5,4 @@ requires "Path::Tiny";
 requires "RT::Client::REST";
 requires "RT::Client::REST::Ticket";
 requires "RT::Client::REST::User";
-requires "Syntax::Keyword::Junction";
 requires "Try::Tiny";

--- a/rt-to-github.pl
+++ b/rt-to-github.pl
@@ -12,7 +12,6 @@ use Path::Tiny;
 use RT::Client::REST;
 use RT::Client::REST::Ticket;
 use RT::Client::REST::User;
-use Syntax::Keyword::Junction qw/any/;
 use Try::Tiny;
 use Getopt::Long;
 


### PR DESCRIPTION
It isn't actually used for anything